### PR TITLE
Node: apt-get update before install, bin/node changed to nodejs

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 MAINTAINER Kimbro Staken
 
 RUN apt-get update
-RUN apt-get install -y python-software-properties python
+RUN apt-get install -y software-properties-common python
 RUN add-apt-repository ppa:chris-lea/node.js
 RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ precise universe" >> /etc/apt/sources.list
 RUN apt-get install -y nodejs

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,14 +1,13 @@
 FROM ubuntu
 MAINTAINER Kimbro Staken
 
+RUN apt-get update
 RUN apt-get install -y python-software-properties python
 RUN add-apt-repository ppa:chris-lea/node.js
 RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ precise universe" >> /etc/apt/sources.list
-RUN apt-get update
 RUN apt-get install -y nodejs
-#RUN apt-get install -y nodejs=0.6.12~dfsg1-1ubuntu1
 RUN mkdir /var/www
 
 ADD app.js /var/www/app.js
 
-CMD ["/usr/bin/node", "/var/www/app.js"] 
+CMD ["/usr/bin/nodejs", "/var/www/app.js"] 


### PR DESCRIPTION
/usr/bin/node changed to /usr/bin/nodejs recently and add-apt-repository was moved to software-properties-common
