### PR TITLE
Update the software-properties package on ubuntu

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 MAINTAINER Kimbro Staken
 
-RUN apt-get install -y python-software-properties python
+RUN apt-get install -y software-properties-common python
 RUN add-apt-repository ppa:chris-lea/node.js
 RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ precise universe" >> /etc/apt/sources.list
 RUN apt-get update


### PR DESCRIPTION
When building the image, python-software-properties returns an error:

```
Package python-software-properties is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  software-properties-common

E: Package 'python-software-properties' has no installation candidate
The command '/bin/sh -c apt-get install -y python-software-properties python' returned a non-zero code: 100
```

This commit fixes the issue.
